### PR TITLE
Fix de l'erreur "Module not found" quand un package utilise l'ESM

### DIFF
--- a/config.client.js
+++ b/config.client.js
@@ -20,6 +20,16 @@ function setupRules(
   return [
     // JS LOADER
     {
+      /*
+      - To solve this issue
+        https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
+      */
+      test: /\.(mjs|js)$/,
+      resolve: {
+        fullySpecified: false,
+      },
+    },
+    {
       test: /\.jsx?$/,
       include: additionalIncludes.length
         ? [


### PR DESCRIPTION
Actuellement, quand on passe `redux` vers sa version `4.1.0` le `make serve` sur `hydra` produit cette erreur ![redux](https://user-images.githubusercontent.com/47597252/117644873-3f44aa80-b18a-11eb-8941-05ab4aea0401.png)

En investiguant, j'ai trouvé cette [issue](https://github.com/webpack/webpack/issues/11467#issuecomment-691873586) sur le repo de webpack. En appliquant la modification proposée dans le commentaire de l'issue, le build se fait correctement à nouveau.

De ce que j'ai compris, l'origine du problème vient de l'utilisation des ES Modules (esm). A partir du moment où un module utilise l'esm (soit en spécifiant dans son `package.json` la propriété `type="module"`, soit en utilisant l'extension `.mjs`), `webpack` par défaut oblige l'utilisateur à préciser l'extension des fichiers lors des imports. Pour [désactiver](
https://webpack.js.org/configuration/module/#resolvefullyspecified) ce comportement par défaut, il faut le spécifier dans `module.rules.resolve`

```js
// webpack.config.js
module.exports = {
  // ...
  module: {
    rules: [
      {
        test: /\.m?js$/,
        resolve: {
          fullySpecified: false, // disable the behaviour
        },
      },
    ],
  },
};
```

```diff
- import foo from "./foo.js"
+ import foo from "./foo" // cette ligne provoque l'erreur avec le comportement par défaut de webpack
```
