### PR TITLE
Ajout de @babel/plugin-proposal-private-methods parmi les plugins babel

### DIFF
--- a/config.client.js
+++ b/config.client.js
@@ -58,6 +58,7 @@ function setupRules(
             ['@babel/plugin-proposal-decorators', { legacy: true }],
             'add-react-static-displayname',
             ['@babel/plugin-proposal-class-properties', { loose: true }],
+            ['@babel/plugin-proposal-private-methods', { loose: true }],
             '@babel/plugin-transform-runtime',
           ],
         },

--- a/config.server.js
+++ b/config.server.js
@@ -36,6 +36,7 @@ function setupRules(dirs, verbose) {
             ['@babel/plugin-proposal-decorators', { legacy: true }],
             'add-react-static-displayname',
             ['@babel/plugin-proposal-class-properties', { loose: true }],
+            ['@babel/plugin-proposal-private-methods', { loose: true }],
             '@babel/plugin-transform-runtime',
           ],
         },


### PR DESCRIPTION
Les dernières maj de babel font apparaître un warning dans la console lors du build. Ce dernier suggère d'ajouter ce plugin lorsqu'on utilise `@babel/plugin-proposal-class-properties` configuré en `loose: true`