### PR TITLE
Silence dart-sass recent deprecations

### DIFF
--- a/config.client.js
+++ b/config.client.js
@@ -95,6 +95,18 @@ function setupRules(
           options: {
             sassOptions: {
               includePaths: [dirs.src, dirs.styles, dirs.modules],
+              /* Disable dart-sass 1.77+ deprecation warnings */
+              quietDeps: true,
+              silenceDeprecations: [
+                'color-4-api',
+                'color-functions',
+                'css-function-mixin',
+                'feature-exists',
+                'global-builtin',
+                'import',
+                'legacy-js-api',
+                'mixed-decls',
+              ],
             },
           },
         },
@@ -119,6 +131,18 @@ function setupRules(
               options: {
                 sassOptions: {
                   includePaths: [dirs.src, dirs.styles, dirs.modules],
+                  /* Disable dart-sass 1.77+ deprecation warnings */
+                  quietDeps: true,
+                  silenceDeprecations: [
+                    'color-4-api',
+                    'color-functions',
+                    'css-function-mixin',
+                    'feature-exists',
+                    'global-builtin',
+                    'import',
+                    'legacy-js-api',
+                    'mixed-decls',
+                  ],
                 },
               },
             },


### PR DESCRIPTION
dart-sass is currently adding several deprecation warnings starting in order to prepare their 2.0 version.

Those are displayed by webpack-dev-server in overlay at page load.

Disable all the recent ones (v1.77+), and enable quietDeps to avoid warnings from dependencies.

Unfortunately, there is no way to disable them all without listing them, so it might be necessary to add the upcoming ones if any.

See:
- https://sass-lang.com/documentation/js-api/interfaces/deprecations/
- https://github.com/sass/dart-sass/issues/2352
- https://github.com/twbs/bootstrap/issues/40962
- https://www.reddit.com/r/bootstrap/comments/1e6i6qg/how_you_guys_are_dealing_with_sass_deprecation/